### PR TITLE
travis-ci: xenial -> bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
 notifications:
   email: false
-dist: xenial
+dist: bionic
 python:
 - "3.5"
 - "3.6"
 - "3.7"
 before_install:
-- sudo add-apt-repository -y ppa:jonathonf/backports
 - sudo apt-get -qq update
 - sudo apt-get install -y libopenjp2-7
 install:


### PR DESCRIPTION
- Fixes #20
- Use Ubuntu 18.04LTS rather than 16.04LTS
- Drop ppa:jonathonf/backports as it is no longer needed