### PR TITLE
Fix for `get_mask_from_prob` to work with single-temporal features.

### DIFF
--- a/tests/test_cloud_detector.py
+++ b/tests/test_cloud_detector.py
@@ -15,16 +15,20 @@ def test_pixel_cloud_detector():
 
     cloud_detector = S2PixelCloudDetector(all_bands=True)
     cloud_probs = cloud_detector.get_cloud_probability_maps(data["s2_im"])
+    cloud_mask_from_prob = cloud_detector.get_mask_from_prob(cloud_probs)
     cloud_mask = cloud_detector.get_cloud_masks(data["s2_im"])
 
     assert np.allclose(cloud_probs, data["cl_probs"], atol=1e-14)
     assert np.array_equal(cloud_mask, data["cl_mask"])
+    assert np.array_equal(cloud_mask_from_prob, data["cl_mask"])
 
     single_temporal_cloud_probs = cloud_detector.get_cloud_probability_maps(data["s2_im"][0, ...])
+    single_temporal_cloud_mask_from_probs = cloud_detector.get_mask_from_prob(single_temporal_cloud_probs)
     single_temporal_cloud_mask = cloud_detector.get_cloud_masks(data["s2_im"][0, ...])
 
     assert np.array_equal(single_temporal_cloud_probs, cloud_probs[0, ...])
     assert np.array_equal(single_temporal_cloud_mask, cloud_mask[0, ...])
+    assert np.array_equal(single_temporal_cloud_mask_from_probs, cloud_mask[0, ...])
 
     cloud_detector = S2PixelCloudDetector(all_bands=False)
     with pytest.raises(ValueError):


### PR DESCRIPTION
The fix moves the check for `is_single_temporal` to corresponding functions (to compute cloud probabilities and consequent masks from the probabilities). 

Additionally, the tests now include running both separate functions as well as one-in-all. 