### PR TITLE
Exclude test folder from releases

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include requirements*.txt
-
 include README.md
 include LICENSE.md
 include setup.py
 include s2cloudless/models/*
 include s2cloudless/py.typed
+
+exclude tests/*


### PR DESCRIPTION
After the 1.7.0 release i discovered that tests get shipped together with the code. For some reason they get included, we had similar issues with some eo-learn subpackages.

A minor annoyance (only 9kB of data) but better to fix it now. I released it as 1.7.0.1 to testPyPI to verify this works (useful trick).