### PR TITLE
Use evalscript generation and timestamp availability utilities from sh-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lightgbm>=2.0.11
 numpy>=1.13.3
 opencv-python-headless
-sentinelhub>=3.8.0
+sentinelhub>=3.9.0
 typing_extensions

--- a/s2cloudless/__init__.py
+++ b/s2cloudless/__init__.py
@@ -2,6 +2,6 @@
 
 from .cloud_detector import S2PixelCloudDetector
 from .pixel_classifier import PixelClassifier
-from .utils import download_bands_and_valid_data_mask, get_timestamps
+from .utils import download_bands_and_valid_data_mask
 
 __version__ = "1.7.0"

--- a/s2cloudless/__init__.py
+++ b/s2cloudless/__init__.py
@@ -2,6 +2,6 @@
 
 from .cloud_detector import S2PixelCloudDetector
 from .pixel_classifier import PixelClassifier
-from .utils import download_bands_and_valid_data_mask, get_s2_evalscript, get_timestamps
+from .utils import download_bands_and_valid_data_mask, get_timestamps
 
 __version__ = "1.7.0"

--- a/s2cloudless/utils.py
+++ b/s2cloudless/utils.py
@@ -78,7 +78,7 @@ def download_bands_and_valid_data_mask(
         data_collection=data_collection,
         bands=bands,
         meta_bands=[data_mask_output],
-        merged_output=bands_output,
+        merged_bands_output=bands_output,
         prioritize_dn=True,
     )
 

--- a/s2cloudless/utils.py
+++ b/s2cloudless/utils.py
@@ -6,54 +6,12 @@ from typing import List, Optional, Tuple
 import cv2
 import numpy as np
 
-from sentinelhub import (
-    BBox,
-    DataCollection,
-    MimeType,
-    SentinelHubCatalog,
-    SentinelHubDownloadClient,
-    SentinelHubRequest,
-    SHConfig,
-    filter_times,
-)
+from sentinelhub import BBox, DataCollection, MimeType, SentinelHubDownloadClient, SentinelHubRequest, SHConfig
 from sentinelhub.evalscript import generate_evalscript
 
 S2_BANDS = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B10", "B11", "B12"]
 MODEL_BAND_IDS = [0, 1, 3, 4, 7, 8, 9, 10, 11, 12]
 MODEL_BANDS = [S2_BANDS[band_idx] for band_idx in MODEL_BAND_IDS]
-
-
-def get_timestamps(
-    bbox: BBox,
-    time_interval: Tuple[dt.datetime, dt.datetime],
-    *,
-    maxcc: Optional[float] = None,
-    data_collection: DataCollection = DataCollection.SENTINEL2_L1C,
-    config: Optional[SHConfig] = None,
-    time_difference: Optional[dt.timedelta] = None,
-) -> List[dt.datetime]:
-    """Get the list of timestamps for which data is available. Takes into account the bbox and time interval."""
-    time_difference = time_difference if time_difference else dt.timedelta(seconds=0)
-
-    catalog = SentinelHubCatalog(config=config)
-    cloud_cover_query = None
-    if maxcc is not None:
-        cloud_cover_query = f"eo:cloud_cover < {100 * float(maxcc)}"
-
-    search_iterator = catalog.search(
-        data_collection,
-        bbox=bbox,
-        time=time_interval,
-        filter=cloud_cover_query,
-        fields={
-            "include": [
-                "properties.datetime",
-            ],
-            "exclude": [],
-        },
-    )
-
-    return filter_times(search_iterator.get_timestamps(), time_difference)
 
 
 # pylint: disable-msg=too-many-locals

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ BBOX2 = BBox(((620000, 8210000), (660000, 8270000)), crs=CRS(32738))
 def config_fixture() -> SHConfig:
     config = SHConfig()
 
-    for param in config.get_params():
+    for param in config.to_dict():
         env_variable = param.upper()
         if os.environ.get(env_variable):
             setattr(config, param, os.environ.get(env_variable))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 
 from sentinelhub import CRS, BBox, SHConfig
 
-from s2cloudless.utils import download_bands_and_valid_data_mask, get_s2_evalscript, get_timestamps
+from s2cloudless.utils import download_bands_and_valid_data_mask, get_timestamps
 
 BBOX1 = BBox([-90.9216499, 14.4190528, -90.8186531, 14.5520163], crs=CRS.WGS84)
 BBOX2 = BBox(((620000, 8210000), (660000, 8270000)), crs=CRS(32738))
@@ -23,22 +23,6 @@ def config_fixture() -> SHConfig:
             setattr(config, param, os.environ.get(env_variable))
 
     return config
-
-
-@pytest.mark.parametrize("all_bands", [True, False])
-@pytest.mark.parametrize("reflectance", [True, False])
-def test_get_s2_evalscript(all_bands: bool, reflectance: bool) -> None:
-    evalscript = get_s2_evalscript(all_bands=all_bands, reflectance=reflectance)
-
-    assert isinstance(evalscript, str)
-
-    bands_num_str = "bands: 14" if all_bands else "bands: 11"
-    assert bands_num_str in evalscript
-
-    input_units_str = 'units: "reflectance"' if reflectance else 'units: "DN"'
-    assert input_units_str in evalscript
-    output_sample_type_str = 'sampleType: "FLOAT32"' if reflectance else 'sampleType: "UINT16"'
-    assert output_sample_type_str in evalscript
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,44 +1,15 @@
 import datetime as dt
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 import pytest
 
 from sentinelhub import CRS, BBox
 
-from s2cloudless.utils import download_bands_and_valid_data_mask, get_timestamps
+from s2cloudless.utils import download_bands_and_valid_data_mask
 
 BBOX1 = BBox((-90.9216499, 14.4190528, -90.8186531, 14.5520163), crs=CRS.WGS84)
 BBOX2 = BBox(((620000, 8210000), (660000, 8270000)), crs=CRS(32738))
-
-
-@pytest.mark.parametrize(
-    "test_input, expected",
-    [
-        ({"bbox": BBOX1, "time_interval": (dt.datetime(2021, 1, 1), dt.datetime(2021, 1, 1))}, []),
-        (
-            {"bbox": BBOX1, "time_interval": (dt.datetime(2021, 1, 1), dt.datetime(2021, 1, 10))},
-            [
-                dt.datetime(2021, 1, 4, 16, 39, 29),
-                dt.datetime(2021, 1, 4, 16, 39, 44),
-                dt.datetime(2021, 1, 9, 16, 39, 29),
-                dt.datetime(2021, 1, 9, 16, 39, 43),
-            ],
-        ),
-        (
-            {
-                "bbox": BBOX1,
-                "time_interval": (dt.datetime(2021, 1, 1), dt.datetime(2021, 1, 10)),
-                "time_difference": dt.timedelta(seconds=600),
-            },
-            [dt.datetime(2021, 1, 4, 16, 39, 29), dt.datetime(2021, 1, 9, 16, 39, 29)],
-        ),
-    ],
-)
-@pytest.mark.sh_integration
-def test_get_timestamps(test_input: dict, expected: List[dt.datetime]) -> None:
-    timestamps = get_timestamps(**test_input)
-    assert [timestamp.replace(tzinfo=None) for timestamp in timestamps] == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Changes:
- removed evalscript generation and used the one from sh-py
- removed the test, since the testing was also ported to sh-py
- small config fix so that it works with `develop` version of `sh-py`

More info:
- Needs https://github.com/sentinel-hub/sentinelhub-py/pull/441 to be merged first
- Tested with `develop` version of `sh-py`